### PR TITLE
Split main tasks per OS family

### DIFF
--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -1,0 +1,12 @@
+---
+- name: set gpg key
+  apt_key:
+    url: "https://packages.microsoft.com/keys/microsoft.asc"
+    state: present
+
+- name: add repository
+  apt_repository:
+    repo: 'deb [arch=amd64] https://packages.microsoft.com/repos/ms-teams stable main'
+    filename: teams
+    state: present
+    update_cache: yes

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -8,5 +8,12 @@
   apt_repository:
     repo: 'deb [arch=amd64] https://packages.microsoft.com/repos/ms-teams stable main'
     filename: teams
+    update_cache: no
     state: present
+
+# Handle cache update on a dedicated task to cover the case where the
+# repository was already added, but the cache was not updated. This also
+# allows to move the cache update out of the package install task.
+- name: APT cache updated
+  apt:
     update_cache: yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,15 +5,13 @@
   include: "{{ ansible_os_family | lower }}.yml"
 
 - name: install teams
-  apt:
+  package:
     name: teams
-    update_cache: true
   when:
     - teams_install | bool
 
 - name: install teams insiders
-  apt:
+  package:
     name: teams-insiders
-    update_cache: true
   when:
     - teams_insiders_install | bool

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,17 +1,8 @@
 ---
 # tasks file for ms-teams
 
-- name: set gpg key
-  apt_key:
-    url: "https://packages.microsoft.com/keys/microsoft.asc"
-    state: present
-
-- name: add repository
-  apt_repository:
-    repo: 'deb [arch=amd64] https://packages.microsoft.com/repos/ms-teams stable main'
-    filename: teams
-    state: present
-    update_cache: yes
+- name: Include tasks for "{{ ansible_os_family }}"
+  include: "{{ ansible_os_family | lower }}.yml"
 
 - name: install teams
   apt:


### PR DESCRIPTION
These changes allow to include other distributions.

- Added include for OS families
- Moved Debian related tasks to debian.yml
- Use package instead of apt for package installs
- Always update cache after repository tasks